### PR TITLE
Add dynamic /status/:code endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use routes::{
     patch as patch_routes,
     delete as delete_routes,
     options as options_routes,
+    status as status_routes, // <-- NEW
 };
+
 
 #[tokio::main]
 async fn main() {
@@ -28,6 +30,7 @@ async fn main() {
     .route("/patch", patch(patch_routes::patch_handler))
     .route("/delete", delete(delete_routes::delete_handler))
     .route("/options", options(options_routes::options_handler))
+    .route("/status/:code", get(status_routes::status_handler))
     .layer(TraceLayer::new_for_http());
 
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -4,3 +4,4 @@ pub mod put;
 pub mod patch;
 pub mod delete;
 pub mod options;
+pub mod status;

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -1,0 +1,14 @@
+use axum::{
+    extract::Path,
+    http::StatusCode,
+    response::Response,
+};
+
+pub async fn status_handler(Path(code): Path<u16>) -> Response {
+    let status = StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_REQUEST);
+
+    Response::builder()
+        .status(status)
+        .body(axum::body::Body::empty())
+        .unwrap()
+}


### PR DESCRIPTION
Added /status/:code endpoint
Responds with specified HTTP status or 400 Bad Request if invalid
Useful for client and infrastructure testing